### PR TITLE
Add HardwareTable component

### DIFF
--- a/docs/.vuepress/components/HardwareTable.vue
+++ b/docs/.vuepress/components/HardwareTable.vue
@@ -66,13 +66,31 @@ export default {
 <template>
   <div>
     <div class="table-container">
+      <div class="button-prefix">
+        Length unit:
+      </div>
       <div class="table-button" @click="toggleLength">
-        Length: {{ activeLength }}
+        <template v-if="activeLength === 'cm'">
+          <b>cm</b> / inch
+        </template>
+        <template v-else>
+          cm / <b>inch</b>
+        </template>
+      </div>
+
+      <div class="button-prefix">
+        Voltage:
       </div>
       <div class="table-button" @click="toggleVoltage">
-        Voltage: {{ activeVoltage }}
+        <template v-if="activeVoltage === '230V'">
+          <b>230V</b> / 240V
+        </template>
+        <template v-else>
+          230V / <b>240V</b>
+        </template>
       </div>
     </div>
+
     <div class="table-container">
       <div
         v-for="c in tableValues"
@@ -104,11 +122,10 @@ export default {
   display: flex;
   flex-flow: column nowrap;
   flex: 1 0 auto;
-  border-left: 0.1em solid #bbbbbb;
   margin: 0.5em 0;
 }
-.column:last-child {
-  border-right: 0.1em solid #bbbbbb;
+.column:not(:first-child) {
+  border-left: 0.1em solid #bbbbbb;
 }
 .column > div:nth-child(odd) {
   background: #dddddd;
@@ -116,6 +133,11 @@ export default {
 .table > div {
   padding: 3px 5px;
   flex: 1 0 0;
+}
+
+.button-prefix {
+  padding: 0.2em 0.5em 0.2em 0;
+  align-self: center;
 }
 
 .table-button {

--- a/docs/.vuepress/components/HardwareTable.vue
+++ b/docs/.vuepress/components/HardwareTable.vue
@@ -1,0 +1,138 @@
+<script>
+export default {
+  name: 'HardwareTable',
+  props: {
+    columns: {
+      type: Array,
+      default: () => ([
+        {
+          title: '#',
+          values: [0, 9, 8, 7, 6],
+          // no length / voltage property -> always shown
+        },
+        {
+          title: 'Diameter (cm)',
+          values: [1, 2, 3],
+          length: 'cm', // Only shown if activeLength === 'cm'
+          // No voltage property set -> shown regardless of active voltage
+        },
+        {
+          title: 'Diameter (in)',
+          values: [4, 5, 6],
+          length: 'inch',
+        },
+        {
+          title: 'Power (W)',
+          values: [1, 2, 3],
+          voltage: '230V', // Only shown if activeVoltage === '230V'
+          // No length property set -> shown regardless of active length
+        },
+        {
+          title: 'Power (W)',
+          values: [4, 5, 6],
+          voltage: '240V',
+        },
+      ]),
+    },
+  },
+  data: () => ({
+    activeLength: 'cm',
+    activeVoltage: '230V',
+  }),
+  computed: {
+    tableValues () {
+      return this.columns
+        .map((c, idx) => ({ ...c, key: `col-${idx}-${c.title}` }))
+        .filter(c =>
+          (!c.voltage && !c.length)
+          || c.voltage === this.activeVoltage
+          || c.length === this.activeLength);
+    },
+    numRows () {
+      return Math.max(...this.columns.map(c => c.values.length));
+    },
+  },
+  methods: {
+    toggleLength () {
+      this.activeLength = this.activeLength === 'cm' ? 'inch' : 'cm';
+    },
+    toggleVoltage () {
+      this.activeVoltage = this.activeVoltage === '230V' ? '240V' : '230V';
+    },
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="table-container">
+      <div class="table-button" @click="toggleLength">
+        Length: {{ activeLength }}
+      </div>
+      <div class="table-button" @click="toggleVoltage">
+        Voltage: {{ activeVoltage }}
+      </div>
+    </div>
+    <div class="table-container">
+      <div
+        v-for="c in tableValues"
+        :key="c.key"
+        class="column table"
+      >
+        <div>{{ c.title }}</div>
+        <div
+          v-for="num in numRows"
+          :key="`${c.key}-value-${num}`"
+        >
+          {{ c.values[num - 1] }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.table-container {
+  display: flex;
+  min-width: 100%;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  align-items: stretch;
+  overflow-x: auto;
+}
+.column {
+  display: flex;
+  flex-flow: column nowrap;
+  flex: 1 0 auto;
+  border-left: 0.1em solid #bbbbbb;
+  margin: 0.5em 0;
+}
+.column:last-child {
+  border-right: 0.1em solid #bbbbbb;
+}
+.column > div:nth-child(odd) {
+  background: #dddddd;
+}
+.table > div {
+  padding: 3px 5px;
+  flex: 1 0 0;
+}
+
+.table-button {
+  padding: 0.2em 1em;
+  border: 0.16em solid #bbbbbb;
+  margin: 0 0.3em 0.3em 0;
+  cursor: pointer;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+}
+.table-button:hover {
+  background: #dddddd;
+   border-color: #dddddd;
+}
+.table-button:active {
+  background: #bbbbbb;
+   border-color: #bbbbbb;
+}
+</style>

--- a/docs/.vuepress/components/TableRound.vue
+++ b/docs/.vuepress/components/TableRound.vue
@@ -1,0 +1,115 @@
+<script>
+export default {
+  name: 'TableRound',
+  data: () => ({
+    values: [
+      {
+        title: '#',
+        values: [6, 7, 11, 1, 2, 3, 4, 5, 8, 9, 10],
+      },
+      {
+        title: 'Diameter (cm)',
+        length: 'cm',
+        values: [30, 35, 25.5, 35, 40, 50, 60, 80, 25, 30, 35],
+      },
+      {
+        title: 'Length (cm)',
+        length: 'cm',
+        values: [35, 40, 30.5, 40, 45, 56.5, 66, 86.5, 30, 35, 40],
+      },
+      {
+        title: 'Min. kettle ⌀ (cm)',
+        length: 'cm',
+        values: [36, 41, 32, 41, 46, 57.5, 67, 87.5, 31, 36, 41],
+      },
+      {
+        title: 'Designed for kettle ⌀ (cm)',
+        length: 'cm',
+        values: [40, 45, 35, 45, 50, 63, 72, 93, 35, 40, 45],
+      },
+      {
+        title: 'Diameter (in)',
+        length: 'inch',
+        values: [11.8, 13.8, 10.0, 13.8, 15.7, 19.7, 23.6, 31.5, 9.8, 11.8, 13.8].map(v => v.toFixed(1)),
+      },
+      {
+        title: 'Length (in)',
+        length: 'inch',
+        values: [13.8, 15.7, 12.0, 15.7, 17.7, 22.2, 26.0, 34.1, 11.8, 13.8, 15.7].map(v => v.toFixed(1)),
+      },
+      {
+        title: 'Min. kettle ⌀ (in)',
+        length: 'inch',
+        values: [14.2, 16.1, 12.6, 16.1, 18.1, 22.6, 26.4, 34.4, 12.2, 14.2, 16.1].map(v => v.toFixed(1)),
+      },
+      {
+        title: 'Designed for kettle ⌀ (in)',
+        length: 'inch',
+        values: [15.7, 17.7, 13.8, 17.7, 19.7, 24.8, 28.3, 36.6, 13.8, 15.7, 17.7].map(v => v.toFixed(1)),
+      },
+      {
+        title: 'No. Resistors',
+        values: [1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3],
+      },
+      {
+        title: 'Current (A)',
+        voltage: '230V',
+        values: [
+          '15.2x1',
+          '15.2x1',
+          '12.2x1',
+          '12.3x3',
+          '12.3x3',
+          '14.5x3',
+          '14.5x3',
+          '21.7x3',
+          '8.0x3',
+          '8.0x3',
+          '8.0x3',
+        ],
+      },
+      {
+        title: 'Power (W)',
+        voltage: '230V',
+        values: [3500, 3500, 2800, 8500, 8500, 10000, 10000, 15000, 5500, 5500, 5500],
+      },
+      {
+        title: 'Watt density (W/cm²)',
+        voltage: '230V',
+        values: [10.7, 9.2, 10.3, 7.5, 6.5, 6.1, 5.1, 5.8, 6.8, 5.6, 4.8],
+      },
+      {
+        title: 'Current (A)',
+        voltage: '240V',
+        values: [
+          '15.9x1',
+          '15.9x1',
+          '12.7x1',
+          '12.9x3',
+          '12.9x3',
+          '15.1x3',
+          '15.1x3',
+          '22.7x3',
+          '8.3x3',
+          '8.3x3',
+          '8.3x3',
+        ],
+      },
+      {
+        title: 'Power (W)',
+        voltage: '240V',
+        values: [3800, 3800, 3050, 9250, 9250, 10900, 10900, 16350, 6000, 6000, 6000],
+      },
+      {
+        title: 'Watt density (W/cm²)',
+        voltage: '240V',
+        values: [11.7, 10.0, 11.2, 8.2, 7.1, 6.6, 5.6, 6.3, 7.4, 6.1, 5.2].map(v => v.toFixed(1)),
+      },
+    ],
+  }),
+};
+</script>
+
+<template>
+  <HardwareTable :columns="values" />
+</template>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6"
+  },
+  "exclude": [
+    "node_modules",
+    ".cache",
+    ".temp",
+    ".vscode",
+    "docs/.vuepress/dist"
+  ]
+}


### PR DESCRIPTION
Table columns are provided as properties, and can have length/voltage specified.
If length or voltage is set, the column is only shown if it matches active length or voltage.

Example implementation of TableRound is also added: this uses the HardwareTable component with preset values.

Buttons to toggle active length or voltage are shown above the table.