### PR TITLE
Edge release

### DIFF
--- a/docs/user/release_notes.md
+++ b/docs/user/release_notes.md
@@ -8,6 +8,38 @@ Relevant links:
 - Project board: <https://github.com/orgs/Brewblox/projects/1>
 - Code repositories: <https://github.com/Brewblox>
 
+## Brewblox release 2023/02/23
+
+**firmware release date: 2023-02-22**
+
+With this release, the Spark simulator is no longer based on the Spark 3.
+Some of the changes are immediately noticeable:
+
+- The *Spark Sim Display* now uses the Spark 4 display library.
+- The simulator no longer pretends it only has 2kB EEPROM.
+- The simulator no longer has a *Spark 3 Pins* block.
+- The simulator no longer automatically "discovers" temp sensor and DS2408/DS2413 blocks.
+
+Other changes are still in progress. A simulated *OneWire GPIO Module* block will be included in a future release.
+
+**If you already have a simulator service, you will need to reload its active blocks from a backup.**
+Block backups are generated automatically on a daily basis, and can be accessed from *Admin* -> *Services* -> *{service name}* -> *Controller backups*.
+
+**Changes**
+
+- (feature) The Spark sim has been updated.
+- (feature) The Spark Sim Display widget now shows the Spark 4 display.
+- (feature) Reworked constraints to be more straightforward.
+- (feature) The *Balancer* and *Mutex* block now show an overview of clients and potential clients.
+- (improve) The firmware update dialog now replaces the "flash" button with "close" if the flash was successful.
+- (improve) Spark backups are now sorted to display the latest first.
+- (improve) The Claims field in blocks now lets you navigate to all blocks in the chain.
+- (improve) Builder flows are now updated correctly when an actuator linked to an L-Valve changes state.
+- (fix) Resolved various system problems if IPv6 was disabled in the kernel.
+- (fix) Fixed an issue where the PID integral could reach the limits of the number type used to store it.
+- (deprecate) brewblox-ctl no longer supports Python 3.6 (last seen in Ubuntu 18.04).
+- (deprecate) brewblox-ctl no longer automatically adds the `automation-ui` service if an automation service was detected.
+
 ## Brewblox release 2023/01/26
 
 **firmware release date: 2023-01-11**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4798,9 +4798,9 @@ htmlparser2@^8.0.1:
     entities "^4.3.0"
 
 http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http-deceiver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
- Add instructions for installing a tilt service on a Pi zero W
- Bump follow-redirects from 1.14.7 to 1.14.8
- Bump url-parse from 1.5.4 to 1.5.7
- fix various broken links
- Bump prismjs from 1.26.0 to 1.27.0
- Bump url-parse from 1.5.7 to 1.5.10
- document updated spark protocol
- remove WIP layout notes
- spark communication doc tweaks
- Bump minimist from 1.2.5 to 1.2.6
- apply fixes for linter / link checker errors
- Bump async from 2.6.3 to 2.6.4
- shuffle guides; add pi alternatives doc
- explicitly suggest SD card size
- fix tip insert syntax in comms doc
- sequence block decision
- dependency upgrade
- Split spark setup section in startup
- reword cmd introduction in startup
- Add documentation for sequence instructions
- add TempSensorExternal to block documentation
- update Spark state interface
- remove groups from block documentation
- pull updated block types
- Bump terser from 4.8.0 to 4.8.1
- Document DateString in block types
- mention Spark 4 VID:PID in troubleshooting
- fix wireguard guide typos
- validate links in markdown
- Mention disable IPv6 in troubleshooting
- load shared types as yarn dependency
- List WG-Easy as alternative to host wireguard install
- add release notes draft
- add fast pwm / soft start changes to release notes
- pull proto; update block types for fast pwm
- firmware pull
- add builder label click to release notes
- add onewire fix to release notes
- add sid generation fixes to release notes
- update docs with description of stored / desired
- add inactive-after-unclaim to release notes
- add setpoint driver temperatures to release notes
- pull setpoint driver quantities
- all delta values in offset
- clarify that delta values are used for setpoint driver
- add removal of mutex hold time to release notes
- pull types
- set release date
